### PR TITLE
Fix createTagLink to escape singe and double quotes in the link

### DIFF
--- a/src/ngfw/Recipe.php
+++ b/src/ngfw/Recipe.php
@@ -103,7 +103,7 @@ class Recipe
      */
     public static function createLinkTag($link, $text = '', $attributes = [])
     {
-        $linkTag = '<a href="'.$link.'"';
+        $linkTag = '<a href="'.str_replace(['"', "'"], [urlencode('"'), urlencode("'")], $link).'"';
 
         if (self::validateEmail($link)) {
             $linkTag = '<a href="mailto:'.$link.'"';


### PR DESCRIPTION
Since the previous PR was breaking links, we can just escape single and double quotes